### PR TITLE
Refactor deprecated calls

### DIFF
--- a/PintaGroupFinder.toc
+++ b/PintaGroupFinder.toc
@@ -1,9 +1,9 @@
-## Interface: 120001, 120005
+## Interface: 120007
 ## Name: PintaGroupFinder
 ## Title: |cff45D388Pinta Group Finder|r
 ## Notes: A group finder addon for World of Warcraft.
 ## Author: Pinta365@Github
-## Version: 0.6.10
+## Version: 0.7.0
 ## SavedVariables: PintaGroupFinderDB
 ## SavedVariablesPerCharacter: PintaGroupFinderCharDB
 ## X-Curse-Project-ID: 1443532

--- a/src/Config.lua
+++ b/src/Config.lua
@@ -73,8 +73,11 @@ PGF.defaults = {
             tank = false,
             healer = false,
             tankOrHealer = false,
+            augmentationEvoker = false
         },
+        hideAugmentationEvokers = false,
         hideIncompatibleGroups = false,
+        hideSameSpec = false,
         difficulty = {
             normal = true,
             heroic = true,

--- a/src/FilterContext.lua
+++ b/src/FilterContext.lua
@@ -27,6 +27,8 @@ local activityInfoCache = {}
 ---@field isApplied boolean True if you've applied to this group
 ---@field generalPlaystyle number Playstyle for raids: 1=Learning, 2=Relaxed, 3=Competitive, 4=Carry
 ---@field playstyle number Playstyle for dungeons (0 for raids)
+---@field hasAugmentationEvoker boolean True if group has an augmentation evoker (M+ only)
+---@field hasSameSpec boolean True if group has at least one member with your spec
 --- Raid-specific fields
 ---@field defeatedBosses string[]? Array of defeated boss names (raids only)
 ---@field defeatedBossCount number? Number of bosses defeated (raids only)
@@ -95,6 +97,48 @@ function PGF.BuildFilterContext(resultID, searchResultInfo, memberCounts)
     context.dpsNeeded = memberCounts.DAMAGER_REMAINING or 0
     
     context.mprating = searchResultInfo.leaderOverallDungeonScore or 0
+
+    context.hasAugmentationEvoker = false
+    context.hasSameSpec = false
+
+
+    -- Unused return values intentionally preserved for future use.
+    -- 1. Get the player's Class
+    local playerClassName, playerClassFilename, playerClassID = UnitClass("player")
+
+    -- 2. Get the player's Specialization
+    local currentSpecIndex = GetSpecialization()
+    local playerSpecID, playerSpecName, playerSpecDescription, playerSpecIcon, playerSpecRole = nil, "No Spec", nil, nil, nil
+
+    if currentSpecIndex then
+        playerSpecID, playerSpecName, playerSpecDescription, playerSpecIcon, playerSpecRole = GetSpecializationInfo(currentSpecIndex)
+    end
+
+    PGF.Debug(string.format("[BuildFilterContext] - You are a %s %s", playerSpecName, playerClassName))
+
+    local numMembers = searchResultInfo.numMembers or 0
+    for memberIndex = 1, numMembers do
+
+        if context.hasAugmentationEvoker and context.hasSameSpec then
+            break
+        end
+
+        local role, class, level, specID, exploratory = C_LFGList.GetSearchResultMemberInfo(resultID, memberIndex)
+  
+        if not context.hasAugmentationEvoker and specID and specID:lower() == "augmentation" then
+            context.hasAugmentationEvoker = true         
+            PGF.Debug("[BuildFilterContext] - Found Augmentation Evoker")
+        end
+
+        if not context.hasSameSpec and playerClassFilename and class and playerSpecName and specID then
+            if playerClassFilename:lower() == class:lower() and playerSpecName:lower() == specID:lower() then
+                context.hasSameSpec = true
+                PGF.Debug("[BuildFilterContext] - Found same spec:", playerSpecName)
+            end
+        end
+    end
+    PGF.Debug("[BuildFilterContext] - hasSameSpec:", context.hasSameSpec)
+
     context.age = math.floor((searchResultInfo.age or 0) / 60)
     context.ageSecs = searchResultInfo.age or 0
     
@@ -104,7 +148,7 @@ function PGF.BuildFilterContext(resultID, searchResultInfo, memberCounts)
     context.generalPlaystyle = searchResultInfo.generalPlaystyle or 0
     context.playstyle = searchResultInfo.playstyle or 0
     
-        local _, appStatus = C_LFGList.GetApplicationInfo(resultID)
+    local _, appStatus = C_LFGList.GetApplicationInfo(resultID)
     context.appStatus = appStatus or "none"
     context.isApplied = not (not appStatus or appStatus == "none")
     

--- a/src/FilterContext.lua
+++ b/src/FilterContext.lua
@@ -101,42 +101,63 @@ function PGF.BuildFilterContext(resultID, searchResultInfo, memberCounts)
     context.hasAugmentationEvoker = false
     context.hasSameSpec = false
 
+    -- 1. Player class
+    local playerClassName, playerClassFilename = UnitClass("player")
 
-    -- Unused return values intentionally preserved for future use.
-    -- 1. Get the player's Class
-    local playerClassName, playerClassFilename, playerClassID = UnitClass("player")
+    -- 2. Player spec index
+    local playerSpecIndex = C_SpecializationInfo.GetSpecialization()
 
-    -- 2. Get the player's Specialization
-    local currentSpecIndex = GetSpecialization()
-    local playerSpecID, playerSpecName, playerSpecDescription, playerSpecIcon, playerSpecRole = nil, "No Spec", nil, nil, nil
-
-    if currentSpecIndex then
-        playerSpecID, playerSpecName, playerSpecDescription, playerSpecIcon, playerSpecRole = GetSpecializationInfo(currentSpecIndex)
+    -- 3. Player spec name
+    local playerSpecName = "UNKNOWN"
+    if playerSpecIndex then
+        local _, name = C_SpecializationInfo.GetSpecializationInfo(playerSpecIndex)
+        playerSpecName = name or "UNKNOWN"
     end
 
-    PGF.Debug(string.format("[BuildFilterContext] - You are a %s %s", playerSpecName, playerClassName))
+    local playerClassLower = (playerClassFilename or "UNKNOWN"):lower()
+    local playerSpecLower  = playerSpecName:lower()
+
+    PGF.Debug(string.format(
+        "[BuildFilterContext] - You are a %s %s",
+        playerSpecName,
+        playerClassName
+    ))
 
     local numMembers = searchResultInfo.numMembers or 0
+
     for memberIndex = 1, numMembers do
 
         if context.hasAugmentationEvoker and context.hasSameSpec then
             break
         end
 
-        local role, class, level, specID, exploratory = C_LFGList.GetSearchResultMemberInfo(resultID, memberIndex)
-  
-        if not context.hasAugmentationEvoker and specID and specID:lower() == "augmentation" then
-            context.hasAugmentationEvoker = true         
+        local member = C_LFGList.GetSearchResultPlayerInfo(resultID, memberIndex)
+
+        local memberClassFilename = member and member.classFilename or "UNKNOWN"
+        local memberSpecName      = member and member.specName or "UNKNOWN"
+
+        local memberClassLower = memberClassFilename:lower()
+        local memberSpecLower  = memberSpecName:lower()
+
+        -- Augmentation detection
+        if not context.hasAugmentationEvoker
+            and memberSpecLower == "augmentation"
+        then
+            context.hasAugmentationEvoker = true
             PGF.Debug("[BuildFilterContext] - Found Augmentation Evoker")
         end
 
-        if not context.hasSameSpec and playerClassFilename and class and playerSpecName and specID then
-            if playerClassFilename:lower() == class:lower() and playerSpecName:lower() == specID:lower() then
+        -- Same spec detection 
+        if not context.hasSameSpec then
+            if playerClassLower == memberClassLower
+                and playerSpecLower == memberSpecLower
+            then
                 context.hasSameSpec = true
                 PGF.Debug("[BuildFilterContext] - Found same spec:", playerSpecName)
             end
         end
     end
+
     PGF.Debug("[BuildFilterContext] - hasSameSpec:", context.hasSameSpec)
 
     context.age = math.floor((searchResultInfo.age or 0) / 60)

--- a/src/FilterCore.lua
+++ b/src/FilterCore.lua
@@ -154,6 +154,20 @@ local function PassesFilter(resultID, context, preRoleVectors)
             return false
         end
 
+        if hasRole.augmentationEvoker and not context.hasAugmentationEvoker then
+            return false
+        end
+
+        local hideAugmentationEvokers = filter.hideAugmentationEvokers == true
+        if hideAugmentationEvokers and context.hasAugmentationEvoker then
+            return false
+        end
+
+        local hideSameSpec = filter.hideSameSpec == true
+        if hideSameSpec and context.hasSameSpec then
+            return false
+        end
+
         local dungeonActivities = filter.dungeonActivities
         if dungeonActivities ~= nil then
             local selectedGroupIDs = {}

--- a/src/FilterPanelDungeon.lua
+++ b/src/FilterPanelDungeon.lua
@@ -647,6 +647,92 @@ local function CreateMiscSection(scrollContent)
 
     y = y + 22
 
+
+    -- Has Augmentation Evoker (custom OR filter, not backed by Blizzard's advanced filter)
+    local augmentationCheckbox = CreateFrame("CheckButton", nil, content, "UICheckButtonTemplate")
+    augmentationCheckbox:SetSize(20, 20)
+    augmentationCheckbox:SetPoint("TOPLEFT", content, "TOPLEFT", CONTENT_PADDING, -y)
+
+    local augmentationLabel = content:CreateFontString(nil, "ARTWORK", "GameFontNormalSmall")
+    augmentationLabel:SetPoint("LEFT", augmentationCheckbox, "RIGHT", 5, 0)
+    augmentationLabel:SetText(PGF.L("HAS_AUGMENTATION_EVOKER"))
+
+    augmentationCheckbox:SetScript("OnClick", function(self)
+        local db = PintaGroupFinderDB
+        PGF.EnsureFilter(db)
+        db.filter.hasRole.augmentationEvoker = self:GetChecked()
+        PGF.RefilterResults()
+    end)
+
+    augmentationCheckbox:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:SetText(PGF.L("HAS_AUGMENTATION_EVOKER"))
+        GameTooltip:AddLine(PGF.L("HAS_AUGMENTATION_EVOKER_DESC"), 1, 1, 1, true)
+        GameTooltip:Show()
+    end)
+    augmentationCheckbox:SetScript("OnLeave", GameTooltip_Hide)
+
+    dungeonPanel.augmentationCheckbox = augmentationCheckbox
+
+    y = y + 22
+
+    -- Hide Augmentation Evokers (custom OR filter, not backed by Blizzard's advanced filter)
+    local hideAugmentationCheckbox = CreateFrame("CheckButton", nil, content, "UICheckButtonTemplate")
+    hideAugmentationCheckbox:SetSize(20, 20)
+    hideAugmentationCheckbox:SetPoint("TOPLEFT", content, "TOPLEFT", CONTENT_PADDING, -y)
+
+    local hideAugmentationLabel = content:CreateFontString(nil, "ARTWORK", "GameFontNormalSmall")
+    hideAugmentationLabel:SetPoint("LEFT", hideAugmentationCheckbox, "RIGHT", 5, 0)
+    hideAugmentationLabel:SetText(PGF.L("HIDE_AUGMENTATION_EVOKERS"))
+
+    hideAugmentationCheckbox:SetScript("OnClick", function(self)
+        local db = PintaGroupFinderDB
+        PGF.EnsureFilter(db)
+        db.filter.hideAugmentationEvokers = self:GetChecked()
+        PGF.RefilterResults()
+    end)
+
+    hideAugmentationCheckbox:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:SetText(PGF.L("HIDE_AUGMENTATION_EVOKERS"))
+        GameTooltip:AddLine(PGF.L("HIDE_AUGMENTATION_EVOKERS_DESC"), 1, 1, 1, true)
+        GameTooltip:Show()
+    end)
+    hideAugmentationCheckbox:SetScript("OnLeave", GameTooltip_Hide)
+
+    dungeonPanel.hideAugmentationCheckbox = hideAugmentationCheckbox
+
+    y = y + 22
+
+
+    -- Hide Same Spec (custom OR filter, not backed by Blizzard's advanced filter)
+    local hideSameSpecCheckbox = CreateFrame("CheckButton", nil, content, "UICheckButtonTemplate")
+    hideSameSpecCheckbox:SetSize(20, 20)
+    hideSameSpecCheckbox:SetPoint("TOPLEFT", content, "TOPLEFT", CONTENT_PADDING, -y)
+
+    local hideSameSpecLabel = content:CreateFontString(nil, "ARTWORK", "GameFontNormalSmall")
+    hideSameSpecLabel:SetPoint("LEFT", hideSameSpecCheckbox, "RIGHT", 5, 0)
+    hideSameSpecLabel:SetText(PGF.L("HIDE_SAME_SPEC_GROUPS"))
+
+    hideSameSpecCheckbox:SetScript("OnClick", function(self)
+        local db = PintaGroupFinderDB
+        PGF.EnsureFilter(db)
+        db.filter.hideSameSpec = self:GetChecked()
+        PGF.RefilterResults()
+    end)
+
+    hideSameSpecCheckbox:SetScript("OnEnter", function(self)
+        GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
+        GameTooltip:SetText(PGF.L("HIDE_SAME_SPEC_GROUPS"))
+        GameTooltip:AddLine(PGF.L("HIDE_SAME_SPEC_GROUPS_DESC"), 1, 1, 1, true)
+        GameTooltip:Show()
+    end)
+    hideSameSpecCheckbox:SetScript("OnLeave", GameTooltip_Hide)
+
+    dungeonPanel.hideSameSpecCheckbox = hideSameSpecCheckbox
+
+    y = y + 22
+
     y = y + 5
 
     -- Hide incompatible groups
@@ -1327,6 +1413,12 @@ function PGF.UpdateDungeonPanel()
         local hasRole = (db.filter and db.filter.hasRole) or {}
         dungeonPanel.tankOrHealerCheckbox:SetChecked(hasRole.tankOrHealer == true)
     end
+
+    if dungeonPanel.augmentationCheckbox then
+        local db = PintaGroupFinderDB
+        local hasRole = (db.filter and db.filter.hasRole) or {}
+        dungeonPanel.augmentationCheckbox:SetChecked(hasRole.augmentationEvoker == true)
+    end
     
     if dungeonPanel.ratingBox then
         local advancedFilter = C_LFGList.GetAdvancedFilter()
@@ -1339,6 +1431,18 @@ function PGF.UpdateDungeonPanel()
         end
     end
     
+    if dungeonPanel.hideAugmentationCheckbox then
+        local db = PintaGroupFinderDB
+        local filter = db.filter or {}
+        dungeonPanel.hideAugmentationCheckbox:SetChecked(filter.hideAugmentationEvokers == true)
+    end
+
+    if dungeonPanel.hideSameSpecCheckbox then
+        local db = PintaGroupFinderDB
+        local filter = db.filter or {}
+        dungeonPanel.hideSameSpecCheckbox:SetChecked(filter.hideSameSpec == true)
+    end
+
     if dungeonPanel.hideIncompatibleGroupsCheckbox then
         local db = PintaGroupFinderDB
         local filter = db.filter or {}

--- a/src/Locale.lua
+++ b/src/Locale.lua
@@ -57,7 +57,7 @@ local defaultLocale = {
     ["HIDE_INCOMPATIBLE_GROUPS"] = "Hide incompatible groups",
     ["HIDE_INCOMPATIBLE_GROUPS_DESC"] = "Only show groups that have room for your party's roles (tank/healer/DPS). When solo, hides groups that need none of your selected roles.",
     ["HIDE_SAME_SPEC_GROUPS"] = "Hide groups with the same specialization",
-    ["HIDE_SAME_SPEC_GROUPS_DESC"] = "Only show groups that do not contain your specilization.",
+    ["HIDE_SAME_SPEC_GROUPS_DESC"] = "Only show groups that do not contain your specialization.",
      
     -- Role Requirements
     ["ROLE_REQUIREMENTS"] = "Role Requirements",

--- a/src/Locale.lua
+++ b/src/Locale.lua
@@ -50,9 +50,15 @@ local defaultLocale = {
     ["HAS_HEALER_DESC"] = "Only show groups that already have a healer.",
     ["HAS_TANK_OR_HEALER"] = "Has Tank or Healer",
     ["HAS_TANK_OR_HEALER_DESC"] = "Only show groups that already have either a tank or a healer (or both).",
+    ["HAS_AUGMENTATION_EVOKER"] = "Has Augmentation Evoker",
+    ["HAS_AUGMENTATION_EVOKER_DESC"] = "Only show groups that contain an Augmentation Evoker.",
+    ["HIDE_AUGMENTATION_EVOKERS"] = "Hide groups with Augmentation Evoker",
+    ["HIDE_AUGMENTATION_EVOKERS_DESC"] = "Only show groups that do not contain an Augmentation Evoker.",
     ["HIDE_INCOMPATIBLE_GROUPS"] = "Hide incompatible groups",
     ["HIDE_INCOMPATIBLE_GROUPS_DESC"] = "Only show groups that have room for your party's roles (tank/healer/DPS). When solo, hides groups that need none of your selected roles.",
-    
+    ["HIDE_SAME_SPEC_GROUPS"] = "Hide groups with the same specialization",
+    ["HIDE_SAME_SPEC_GROUPS_DESC"] = "Only show groups that do not contain your specilization.",
+     
     -- Role Requirements
     ["ROLE_REQUIREMENTS"] = "Role Requirements",
     ["ROLE_REQ_DESC"] = "Filter groups by exact role counts (e.g., at least 2 healers).",


### PR DESCRIPTION
## Summary
Improves player and group member specialization detection in the filter context system by replacing older API usage, adding safer handling of incomplete Blizzard API responses, and making class/spec comparisons more reliable.

This change improves the stability of filters that depend on group composition detection, especially during LFG updates where member information may not be fully populated.

## Changes

- Replaced deprecated player specialization APIs:
  - Changed `GetSpecialization()` to `C_SpecializationInfo.GetSpecialization()`
  - Changed `GetSpecializationInfo()` to `C_SpecializationInfo.GetSpecializationInfo()`

- Updated player specialization detection:
  - Added safer handling when specialization information is unavailable
  - Added fallback `"UNKNOWN"` values to prevent nil comparison issues
  - Removed unused specialization return values

- Updated LFG member inspection:
  - Replaced `C_LFGList.GetSearchResultMemberInfo()` usage with `C_LFGList.GetSearchResultPlayerInfo()`
  - Improved access to member class and specialization information

- Improved group composition detection:
  - Added normalized lowercase class/spec comparisons
  - Reduced repeated string conversions during filtering
  - Added safer handling for missing member data
  - Preserved early exit behavior once Augmentation Evoker and same-spec detection are resolved


## Bug Fixes

- Fixed potential errors caused by nil specialization values during group filtering
- Prevented failed comparisons when LFG member information is incomplete or unavailable
- Improved reliability of:
  - Augmentation Evoker detection
  - Same specialization detection

## Testing

- Opened Group Finder and verified filtering continues to work normally
- Verified groups containing Augmentation Evokers are detected correctly
- Verified groups containing the player's specialization are detected correctly